### PR TITLE
셀을 스와이프해서 저장된 북마크를 삭제. #7

### DIFF
--- a/BookmarkApp/BookmarkTableViewController.swift
+++ b/BookmarkApp/BookmarkTableViewController.swift
@@ -38,6 +38,18 @@ class BookmarkTableViewController: UITableViewController {
         return bookmarkArray.count
     }
 
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        let removeCell = UIContextualAction(style: .destructive, title: "삭제") { (UIContextualAction, UIView, (Bool) -> Void) in
+            self.bookmarkArray.remove(at: indexPath.row)
+            self.setBookmarkUserDeafaults()
+        }
+        
+        let fullSwipeAction = UISwipeActionsConfiguration(actions: [removeCell])
+        fullSwipeAction.performsFirstActionWithFullSwipe = false
+        
+        return fullSwipeAction
+    }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! BookmarkTableViewCell
@@ -70,12 +82,7 @@ class BookmarkTableViewController: UITableViewController {
                 }
             }
             
-            if let encode = try? JSONEncoder().encode(self.bookmarkArray) {
-                    self.defaults.set(encode, forKey: "bookmark")
-
-            }
-            
-            self.tableView.reloadData()
+            self.setBookmarkUserDeafaults()
             
         }
         
@@ -94,5 +101,12 @@ class BookmarkTableViewController: UITableViewController {
         
         present(alert, animated: true)
         
+    }
+    
+    func setBookmarkUserDeafaults() {
+        if let encode = try? JSONEncoder().encode(self.bookmarkArray) {
+            self.defaults.set(encode, forKey: "bookmark")
+        }
+        self.tableView.reloadData()
     }
 }


### PR DESCRIPTION
tableView(_:trailingSwipeActionsConfigurationForRowAt:) 함수를 override 하고
함수 내부에 셀(북마크 객체 배열에 있는 선택된 셀)을 삭제하고, UserDefaults 에 새로운 북마크객체배열을 저장하는  코드를 구현한 UIContextualAction 객체를 생성하고 리턴합니다.
UISwipeActionsConfiguration 객체의 performsFirstActionWithFullSwipe 옵션을 false 로 설정해서 
풀 스와이프 기능을 비활성화 했습니다.

북마크 객체 배열을 수정하고, 수정된 객체 배열을 다시 UserDefaults 에 저장하는 코드가 중복되는 곳이 있어서
setBookmarkUserDeafaults() 함수를 만들어 대체 했습니다.