### PR TITLE
저장된 북마크 url 주소를 클립보드에 복사한다. #8

### DIFF
--- a/BookmarkApp/BookmarkTableViewController.swift
+++ b/BookmarkApp/BookmarkTableViewController.swift
@@ -59,6 +59,10 @@ class BookmarkTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        let pasteboard = UIPasteboard.general
+        pasteboard.string = self.bookmarkArray[indexPath.row].url
+        
         tableView.deselectRow(at: indexPath, animated: true)
     }
     


### PR DESCRIPTION
tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) 함수 안에 
복사-붙여넣기를 systewide 로 사용할수 있는 general 속성을 가지고 있는 UIPasteboard 객체를 생성했습니다. 
해당 객체의 string 프로퍼티에 선택된 셀 북마크 객체의 url 텍스트를 저장합니다.